### PR TITLE
MEDIUM FIX: Identification Coordinations - Add row validation before csv persistence

### DIFF
--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Exceptions.PersistCsvIdentificationRequests.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Exceptions.PersistCsvIdentificationRequests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using ISL.ReIdentification.Core.Models.Coordinations.Identifications.Exceptions;
 using ISL.ReIdentification.Core.Models.Orchestrations.Accesses;
+using ISL.ReIdentification.Core.Services.Coordinations.Identifications;
 using Moq;
 using Xeptions;
 
@@ -22,8 +23,19 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             // given
             AccessRequest someAccessRequest = CreateRandomAccessRequest();
 
-            this.persistanceOrchestrationServiceMock.Setup(service =>
-                service.PersistCsvIdentificationRequestAsync(someAccessRequest))
+            var identificationCoordinationServiceMock = new Mock<IdentificationCoordinationService>
+                (this.accessOrchestrationServiceMock.Object,
+                this.persistanceOrchestrationServiceMock.Object,
+                this.identificationOrchestrationServiceMock.Object,
+                this.csvHelperBrokerMock.Object,
+                this.securityBrokerMock.Object,
+                this.loggingBrokerMock.Object,
+                this.dateTimeBrokerMock.Object,
+                this.projectStorageConfiguration)
+            { CallBase = true };
+
+            identificationCoordinationServiceMock.Setup(service =>
+                service.ConvertCsvIdentificationRequestToIdentificationRequest(It.IsAny<AccessRequest>()))
                     .ThrowsAsync(dependencyValidationException);
 
             var expectedIdentificationCoordinationDependencyValidationException =
@@ -32,8 +44,11 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                         "fix the errors and try again.",
                     innerException: dependencyValidationException.InnerException as Xeption);
 
+            IdentificationCoordinationService identificationCoordinationService =
+                identificationCoordinationServiceMock.Object;
+
             // when
-            ValueTask<AccessRequest> accessRequestTask = this.identificationCoordinationService
+            ValueTask<AccessRequest> accessRequestTask = identificationCoordinationService
                 .PersistsCsvIdentificationRequestAsync(someAccessRequest);
 
             IdentificationCoordinationDependencyValidationException
@@ -45,8 +60,8 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             actualIdentificationCoordinationDependencyValidationException
                 .Should().BeEquivalentTo(expectedIdentificationCoordinationDependencyValidationException);
 
-            this.persistanceOrchestrationServiceMock.Verify(service =>
-                service.PersistCsvIdentificationRequestAsync(someAccessRequest),
+            identificationCoordinationServiceMock.Verify(service =>
+                service.ConvertCsvIdentificationRequestToIdentificationRequest(It.IsAny<AccessRequest>()),
                     Times.Once);
 
             this.loggingBrokerMock.Verify(broker =>
@@ -55,9 +70,12 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                        Times.Once);
 
             this.persistanceOrchestrationServiceMock.VerifyNoOtherCalls();
-            this.loggingBrokerMock.VerifyNoOtherCalls();
             this.accessOrchestrationServiceMock.VerifyNoOtherCalls();
             this.identificationOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.csvHelperBrokerMock.VerifyNoOtherCalls();
+            this.securityBrokerMock.VerifyNoOtherCalls();
+            this.dateTimeBrokerMock.VerifyNoOtherCalls();
         }
 
         [Theory]
@@ -68,8 +86,19 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             // given
             AccessRequest someAccessRequest = CreateRandomAccessRequest();
 
-            this.persistanceOrchestrationServiceMock.Setup(service =>
-                service.PersistCsvIdentificationRequestAsync(someAccessRequest))
+            var identificationCoordinationServiceMock = new Mock<IdentificationCoordinationService>
+                (this.accessOrchestrationServiceMock.Object,
+                this.persistanceOrchestrationServiceMock.Object,
+                this.identificationOrchestrationServiceMock.Object,
+                this.csvHelperBrokerMock.Object,
+                this.securityBrokerMock.Object,
+                this.loggingBrokerMock.Object,
+                this.dateTimeBrokerMock.Object,
+                this.projectStorageConfiguration)
+            { CallBase = true };
+
+            identificationCoordinationServiceMock.Setup(service =>
+                service.ConvertCsvIdentificationRequestToIdentificationRequest(It.IsAny<AccessRequest>()))
                     .ThrowsAsync(dependencyException);
 
             var expectedIdentificationCoordinationDependencyException =
@@ -78,8 +107,11 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                         "fix the errors and try again.",
                     innerException: dependencyException.InnerException as Xeption);
 
+            IdentificationCoordinationService identificationCoordinationService =
+                identificationCoordinationServiceMock.Object;
+
             // when
-            ValueTask<AccessRequest> accessRequestTask = this.identificationCoordinationService
+            ValueTask<AccessRequest> accessRequestTask = identificationCoordinationService
                 .PersistsCsvIdentificationRequestAsync(someAccessRequest);
 
             IdentificationCoordinationDependencyException
@@ -91,8 +123,8 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             actualIdentificationCoordinationDependencyException
                 .Should().BeEquivalentTo(expectedIdentificationCoordinationDependencyException);
 
-            this.persistanceOrchestrationServiceMock.Verify(service =>
-                service.PersistCsvIdentificationRequestAsync(someAccessRequest),
+            identificationCoordinationServiceMock.Verify(service =>
+                service.ConvertCsvIdentificationRequestToIdentificationRequest(It.IsAny<AccessRequest>()),
                     Times.Once);
 
             this.loggingBrokerMock.Verify(broker =>
@@ -101,9 +133,12 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                        Times.Once);
 
             this.persistanceOrchestrationServiceMock.VerifyNoOtherCalls();
-            this.loggingBrokerMock.VerifyNoOtherCalls();
             this.accessOrchestrationServiceMock.VerifyNoOtherCalls();
             this.identificationOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.csvHelperBrokerMock.VerifyNoOtherCalls();
+            this.securityBrokerMock.VerifyNoOtherCalls();
+            this.dateTimeBrokerMock.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -113,8 +148,19 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             AccessRequest someAccessRequest = CreateRandomAccessRequest();
             Exception someException = new Exception();
 
-            this.persistanceOrchestrationServiceMock.Setup(service =>
-                service.PersistCsvIdentificationRequestAsync(someAccessRequest))
+            var identificationCoordinationServiceMock = new Mock<IdentificationCoordinationService>
+                (this.accessOrchestrationServiceMock.Object,
+                this.persistanceOrchestrationServiceMock.Object,
+                this.identificationOrchestrationServiceMock.Object,
+                this.csvHelperBrokerMock.Object,
+                this.securityBrokerMock.Object,
+                this.loggingBrokerMock.Object,
+                this.dateTimeBrokerMock.Object,
+                this.projectStorageConfiguration)
+            { CallBase = true };
+
+            identificationCoordinationServiceMock.Setup(service =>
+                service.ConvertCsvIdentificationRequestToIdentificationRequest(It.IsAny<AccessRequest>()))
                     .ThrowsAsync(someException);
 
             var expectedIdentificationCoordinationServiceException =
@@ -123,8 +169,11 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                         "fix the errors and try again.",
                     innerException: someException);
 
+            IdentificationCoordinationService identificationCoordinationService =
+                identificationCoordinationServiceMock.Object;
+
             // when
-            ValueTask<AccessRequest> accessRequestTask = this.identificationCoordinationService
+            ValueTask<AccessRequest> accessRequestTask = identificationCoordinationService
                 .PersistsCsvIdentificationRequestAsync(someAccessRequest);
 
             IdentificationCoordinationServiceException
@@ -136,8 +185,8 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             actualIdentificationCoordinationServiceException
                 .Should().BeEquivalentTo(expectedIdentificationCoordinationServiceException);
 
-            this.persistanceOrchestrationServiceMock.Verify(service =>
-                service.PersistCsvIdentificationRequestAsync(someAccessRequest),
+            identificationCoordinationServiceMock.Verify(service =>
+                service.ConvertCsvIdentificationRequestToIdentificationRequest(It.IsAny<AccessRequest>()),
                     Times.Once);
 
             this.loggingBrokerMock.Verify(broker =>
@@ -145,9 +194,12 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                     Times.Once);
 
             this.persistanceOrchestrationServiceMock.VerifyNoOtherCalls();
-            this.loggingBrokerMock.VerifyNoOtherCalls();
             this.accessOrchestrationServiceMock.VerifyNoOtherCalls();
             this.identificationOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.csvHelperBrokerMock.VerifyNoOtherCalls();
+            this.securityBrokerMock.VerifyNoOtherCalls();
+            this.dateTimeBrokerMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.ConvertCsvIdentificationRequestToIdentificationRequest.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.ConvertCsvIdentificationRequestToIdentificationRequest.cs
@@ -77,7 +77,13 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                 service.MapCsvToObjectAsync<CsvIdentificationItem>(csvDataString, hasHeaderRecord, fieldMappings),
                     Times.Once);
 
+            this.persistanceOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.accessOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.identificationOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
             this.csvHelperBrokerMock.VerifyNoOtherCalls();
+            this.securityBrokerMock.VerifyNoOtherCalls();
+            this.dateTimeBrokerMock.VerifyNoOtherCalls();
         }
     }
 }

--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.ConvertCsvIdentificationRequestToIdentificationRequest.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.ConvertCsvIdentificationRequestToIdentificationRequest.cs
@@ -40,7 +40,9 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                     Identifier = randomCsvIdentificationItems[index].Identifier,
                     IsReidentified = false,
                     Message = String.Empty,
-                    RowNumber = index.ToString()
+                    RowNumber = hasHeaderRecord
+                        ? (index + 2).ToString()
+                        : (index + 1).ToString()
                 };
 
                 convertedIdentificationItems.Add(identificationItem);

--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.PersistCsvIdentificationRequests.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.PersistCsvIdentificationRequests.cs
@@ -2,6 +2,7 @@
 // Copyright (c) North East London ICB. All rights reserved.
 // ---------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Force.DeepCloner;
@@ -26,6 +27,9 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             this.persistanceOrchestrationServiceMock.Setup(service =>
                 service.PersistCsvIdentificationRequestAsync(inputAccessRequest))
                     .ReturnsAsync(outputAccessRequest);
+
+            throw new NotImplementedException();
+            // This needs to be a partial mock so we can vefify the virtual method call
 
             // when
             AccessRequest actualAccessRequest = await this.identificationCoordinationService

--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.PersistCsvIdentificationRequests.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Logic.PersistCsvIdentificationRequests.cs
@@ -36,14 +36,14 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
                 this.projectStorageConfiguration)
             { CallBase = true };
 
-            this.persistanceOrchestrationServiceMock.Setup(service =>
-                service.PersistCsvIdentificationRequestAsync(inputAccessRequest))
-                    .ReturnsAsync(outputAccessRequest);
-
             identificationCoordinationServiceMock.Setup(service =>
                 service.ConvertCsvIdentificationRequestToIdentificationRequest(
                     It.Is(SameAccessRequestAs(inputAccessRequest))))
                         .ReturnsAsync(postConversionAccessRequest);
+
+            this.persistanceOrchestrationServiceMock.Setup(service =>
+                service.PersistCsvIdentificationRequestAsync(inputAccessRequest))
+                    .ReturnsAsync(outputAccessRequest);
 
             IdentificationCoordinationService identificationCoordinationService =
                 identificationCoordinationServiceMock.Object;

--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Validations.ConvertCsvIdentificationRequestToIdentificationRequest.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Validations.ConvertCsvIdentificationRequestToIdentificationRequest.cs
@@ -18,15 +18,16 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
 {
     public partial class IdentificationCoordinationTests
     {
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public async Task
-            ShouldThrowValidationExceptionOnConvertCsvIdentificationRequestIfIdIsInvalidAsync()
+            ShouldThrowValidationExceptionOnConvertCsvIdentificationRequestIfIdIsInvalidAsync(bool hasHeaderRecord)
         {
             // given
             CsvIdentificationRequest randomCsvIdentificationRequest = CreateRandomCsvIdentificationRequest();
             CsvIdentificationRequest invalidCsvIdentificationRequest = randomCsvIdentificationRequest.DeepClone();
-            invalidCsvIdentificationRequest.HasHeaderRecord = true;
-            invalidCsvIdentificationRequest.IdentifierColumnIndex = 3;
+            invalidCsvIdentificationRequest.HasHeaderRecord = hasHeaderRecord;
             string csvIdentificationRequestData = GetRandomString();
             byte[] invalidCsvIdentificationRequestDataByteArray = Encoding.UTF8.GetBytes(csvIdentificationRequestData);
             invalidCsvIdentificationRequest.Data = invalidCsvIdentificationRequestDataByteArray;
@@ -62,9 +63,11 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
 
             for (int i = 0; i < invalidIdentifierCount; i++)
             {
+                int rowAdjustment = hasHeaderRecord ? 2 : 1;
+
                 expectedInvalidIdentificationCoordinationException.UpsertDataList(
-                key: nameof(CsvIdentificationItem.Identifier),
-                value: $"Text is invalid at row {i + 2}");
+                    key: nameof(CsvIdentificationItem.Identifier),
+                    value: $"Text is invalid at row {i + rowAdjustment}");
             }
 
             this.csvHelperBrokerMock.Setup(broker =>

--- a/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Validations.ConvertCsvIdentificationRequestToIdentificationRequest.cs
+++ b/ISL.ReIdentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.Validations.ConvertCsvIdentificationRequestToIdentificationRequest.cs
@@ -1,0 +1,106 @@
+﻿// ---------------------------------------------------------
+// Copyright (c) North East London ICB. All rights reserved.
+// ---------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Force.DeepCloner;
+using ISL.ReIdentification.Core.Models.Coordinations.Identifications;
+using ISL.ReIdentification.Core.Models.Coordinations.Identifications.Exceptions;
+using ISL.ReIdentification.Core.Models.Foundations.CsvIdentificationRequests;
+using ISL.ReIdentification.Core.Models.Orchestrations.Accesses;
+using Moq;
+
+namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifications
+{
+    public partial class IdentificationCoordinationTests
+    {
+        [Fact]
+        public async Task
+            ShouldThrowValidationExceptionOnConvertCsvIdentificationRequestIfIdIsInvalidAsync()
+        {
+            // given
+            CsvIdentificationRequest randomCsvIdentificationRequest = CreateRandomCsvIdentificationRequest();
+            CsvIdentificationRequest invalidCsvIdentificationRequest = randomCsvIdentificationRequest.DeepClone();
+            invalidCsvIdentificationRequest.HasHeaderRecord = true;
+            invalidCsvIdentificationRequest.IdentifierColumnIndex = 3;
+            string csvIdentificationRequestData = GetRandomString();
+            byte[] invalidCsvIdentificationRequestDataByteArray = Encoding.UTF8.GetBytes(csvIdentificationRequestData);
+            invalidCsvIdentificationRequest.Data = invalidCsvIdentificationRequestDataByteArray;
+
+            AccessRequest inputAccessRequest = new AccessRequest
+            {
+                CsvIdentificationRequest = invalidCsvIdentificationRequest
+            };
+
+            int randomNumber = GetRandomNumber();
+            int csvIdentificationItemCount = randomNumber;
+            int invalidIdentifierCount = GetRandomNumber(max: csvIdentificationItemCount, min: 1);
+
+            IQueryable<CsvIdentificationItem> randomCsvIdentificationItems =
+                CreateRandomCsvIdentificationItems(csvIdentificationItemCount);
+
+            IQueryable<CsvIdentificationItem> outputCsvIdentificationItems = randomCsvIdentificationItems.DeepClone();
+            int invalidIdentifierIndex = 0;
+
+            foreach (var item in outputCsvIdentificationItems)
+            {
+                if (invalidIdentifierIndex < invalidIdentifierCount)
+                {
+                    item.Identifier = "";
+                    invalidIdentifierIndex++;
+                }
+            }
+
+            var expectedInvalidIdentificationCoordinationException =
+                new InvalidIdentificationCoordinationException(
+                    message: "Invalid identification coordination exception. " +
+                        "Please correct the errors and try again.");
+
+            for (int i = 0; i < invalidIdentifierCount; i++)
+            {
+                expectedInvalidIdentificationCoordinationException.UpsertDataList(
+                key: nameof(CsvIdentificationItem.Identifier),
+                value: $"Text is invalid at row {i + 2}");
+            }
+
+            this.csvHelperBrokerMock.Setup(broker =>
+                broker.MapCsvToObjectAsync<CsvIdentificationItem>(
+                    csvIdentificationRequestData,
+                    invalidCsvIdentificationRequest.HasHeaderRecord,
+                    It.IsAny<Dictionary<string, int>>()))
+                        .ReturnsAsync(outputCsvIdentificationItems.ToList());
+
+            // when
+            ValueTask<AccessRequest> convertCsvIdentificationRequestTask =
+                this.identificationCoordinationService
+                    .ConvertCsvIdentificationRequestToIdentificationRequest(inputAccessRequest);
+
+            InvalidIdentificationCoordinationException actualCsvIdentificationRequestValidationException =
+                await Assert.ThrowsAsync<InvalidIdentificationCoordinationException>(
+                    testCode: convertCsvIdentificationRequestTask.AsTask);
+
+            // then
+            actualCsvIdentificationRequestValidationException.Should()
+                .BeEquivalentTo(expectedInvalidIdentificationCoordinationException);
+
+            this.csvHelperBrokerMock.Verify(broker =>
+                broker.MapCsvToObjectAsync<CsvIdentificationItem>(
+                    csvIdentificationRequestData,
+                    invalidCsvIdentificationRequest.HasHeaderRecord,
+                    It.IsAny<Dictionary<string, int>>()),
+                        Times.Once);
+
+            this.persistanceOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.accessOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.identificationOrchestrationServiceMock.VerifyNoOtherCalls();
+            this.loggingBrokerMock.VerifyNoOtherCalls();
+            this.csvHelperBrokerMock.VerifyNoOtherCalls();
+            this.securityBrokerMock.VerifyNoOtherCalls();
+            this.dateTimeBrokerMock.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/ISL.ReIdentification.Core/Services/Coordinations/Identifications/IdentificationCoordinationService.Validations.cs
+++ b/ISL.ReIdentification.Core/Services/Coordinations/Identifications/IdentificationCoordinationService.Validations.cs
@@ -3,9 +3,11 @@
 // ---------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using ISL.ReIdentification.Core.Models.Coordinations.Identifications;
 using ISL.ReIdentification.Core.Models.Coordinations.Identifications.Exceptions;
 using ISL.ReIdentification.Core.Models.Foundations.CsvIdentificationRequests;
+using ISL.ReIdentification.Core.Models.Foundations.ReIdentifications;
 using ISL.ReIdentification.Core.Models.Orchestrations.Accesses;
 using ISL.ReIdentification.Core.Models.Orchestrations.Accesses.Exceptions;
 
@@ -66,6 +68,23 @@ namespace ISL.ReIdentification.Core.Services.Coordinations.Identifications
                     $".{nameof(AccessRequest.CsvIdentificationRequest.Filepath)}"));
         }
 
+
+        private void ValidateCsvData(List<IdentificationItem> mappedItems)
+        {
+            List<(dynamic Rule, string Parameter)> rules = new List<(dynamic Rule, string Parameter)>();
+
+            foreach (IdentificationItem item in mappedItems)
+            {
+                rules.Add(
+                    (
+                        Rule: IsInvalidRow(item.Identifier, item.RowNumber),
+                        Parameter: nameof(CsvIdentificationItem.Identifier))
+                    );
+            }
+
+            Validate(rules.ToArray());
+        }
+
         private static void ValidateAccessRequestIsNotNull(AccessRequest accessRequest)
         {
             if (accessRequest is null)
@@ -89,6 +108,12 @@ namespace ISL.ReIdentification.Core.Services.Coordinations.Identifications
         {
             Condition = string.IsNullOrWhiteSpace(value),
             Message = "Text is invalid"
+        };
+
+        private static dynamic IsInvalidRow(string value, string index) => new
+        {
+            Condition = string.IsNullOrWhiteSpace(value),
+            Message = $"Text is invalid at row {index}"
         };
 
         private static dynamic IsInvalid(Object @object) => new

--- a/ISL.ReIdentification.Core/Services/Coordinations/Identifications/IdentificationCoordinationService.cs
+++ b/ISL.ReIdentification.Core/Services/Coordinations/Identifications/IdentificationCoordinationService.cs
@@ -246,10 +246,7 @@ namespace ISL.ReIdentification.Core.Services.Coordinations.Identifications
                 identificationItems.Add(identificationItem);
             }
 
-            //throw new NotImplementedException();
-            // next line is new.  Need validation test for this
             ValidateCsvData(identificationItems);
-
             accessRequest.IdentificationRequest = new IdentificationRequest();
             accessRequest.IdentificationRequest.Id = accessRequest.CsvIdentificationRequest.Id;
             accessRequest.IdentificationRequest.IdentificationItems = identificationItems;

--- a/ISL.ReIdentification.Core/Services/Coordinations/Identifications/IdentificationCoordinationService.cs
+++ b/ISL.ReIdentification.Core/Services/Coordinations/Identifications/IdentificationCoordinationService.cs
@@ -239,14 +239,14 @@ namespace ISL.ReIdentification.Core.Services.Coordinations.Identifications
                     IsReidentified = false,
                     Message = string.Empty,
                     RowNumber = accessRequest.CsvIdentificationRequest.HasHeaderRecord
-                        ? index.ToString() + 2
-                        : index.ToString() + 1
+                        ? (index + 2).ToString()
+                        : (index + 1).ToString()
                 };
 
                 identificationItems.Add(identificationItem);
             }
 
-            throw new NotImplementedException();
+            //throw new NotImplementedException();
             // next line is new.  Need validation test for this
             ValidateCsvData(identificationItems);
 

--- a/ISL.Reidentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.cs
+++ b/ISL.Reidentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.cs
@@ -99,6 +99,9 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
         private static int GetRandomNumber() =>
             new IntRange(max: 15, min: 2).GetValue();
 
+        private static int GetRandomNumber(int max, int min) =>
+            new IntRange(max: max, min: min).GetValue();
+
         private static string GetRandomStringWithLengthOf(int length)
         {
             string result = new MnemonicString(wordCount: 1, wordMinLength: length, wordMaxLength: length).GetValue();
@@ -251,6 +254,13 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
 
             return csvIdentificationItems;
         }
+
+        //private static IQueryable<CsvIdentificationItem> CreateCsvIdentificationItemsWithEmptyIdentifiers(
+        //    int itemCount = 1,
+        //    int blankIdentifierCount = 1)
+        //{
+
+        //}
 
         private static IQueryable<IdentificationItem> CreateRandomIdentificationItems(int count = 0)
         {

--- a/ISL.Reidentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.cs
+++ b/ISL.Reidentification.Core.Tests.Unit/Services/Coordinations/Identifications/IdentificationCoordinationTests.cs
@@ -264,13 +264,6 @@ namespace ISL.ReIdentification.Core.Tests.Unit.Services.Coordinations.Identifica
             return csvIdentificationItems;
         }
 
-        //private static IQueryable<CsvIdentificationItem> CreateCsvIdentificationItemsWithEmptyIdentifiers(
-        //    int itemCount = 1,
-        //    int blankIdentifierCount = 1)
-        //{
-
-        //}
-
         private static IQueryable<IdentificationItem> CreateRandomIdentificationItems(int count = 0)
         {
             if (count == 0)


### PR DESCRIPTION
closes [AB#18532](https://dev.azure.com/NELAnalytics/LondonDataService/_workitems/edit/18532)